### PR TITLE
Made TimePicker more drag and drop and other cleanup

### DIFF
--- a/CustomTimePicker/Controller/ViewController.h
+++ b/CustomTimePicker/Controller/ViewController.h
@@ -6,8 +6,10 @@
 //  Copyright (c) 2014 Amboj Goyal. All rights reserved.
 //
 
-#import <UIKit/UIKit.h>
 #import "CustomTimePicker.h"
-@interface ViewController : UIViewController<CustomTimePickerDlegate>
-@property(nonatomic,strong)UIView *clockView;
+
+@interface ViewController : UIViewController<CustomTimePickerDelegate>
+
+@property (nonatomic,strong) CustomTimePicker *clockView;
+
 @end

--- a/CustomTimePicker/Controller/ViewController.m
+++ b/CustomTimePicker/Controller/ViewController.m
@@ -13,9 +13,12 @@
 @end
 
 @implementation ViewController
-CustomTimePicker *clockView;
+
+@synthesize clockView;
+
 UIButton *initiateClock = nil;
 UILabel * hourLabel = nil;
+
 - (void)viewDidLoad
 {
     [super viewDidLoad];

--- a/CustomTimePicker/CustomTimePicker-Prefix.pch
+++ b/CustomTimePicker/CustomTimePicker-Prefix.pch
@@ -11,6 +11,5 @@
 #endif
 
 #ifdef __OBJC__
-    #import <UIKit/UIKit.h>
     #import <Foundation/Foundation.h>
 #endif

--- a/CustomTimePicker/UI/CustomTimePicker/CustomTimePicker.h
+++ b/CustomTimePicker/UI/CustomTimePicker/CustomTimePicker.h
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 @protocol CustomTimePickerDlegate <NSObject>
 -(void)dismissClockViewWithHours:(NSString *)hours andMinutes:(NSString *)minutes andTimeMode:(NSString *)timeMode;
 @end

--- a/CustomTimePicker/UI/CustomTimePicker/CustomTimePicker.h
+++ b/CustomTimePicker/UI/CustomTimePicker/CustomTimePicker.h
@@ -8,14 +8,16 @@
 
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
-@protocol CustomTimePickerDlegate <NSObject>
+@protocol CustomTimePickerDelegate <NSObject>
+
 -(void)dismissClockViewWithHours:(NSString *)hours andMinutes:(NSString *)minutes andTimeMode:(NSString *)timeMode;
+
 @end
 
 
-@interface CustomTimePicker : UIView<UIGestureRecognizerDelegate>
+@interface CustomTimePicker : UIView <UIGestureRecognizerDelegate>
 
-@property(nonatomic,unsafe_unretained)id<CustomTimePickerDlegate>delegate;
+@property (nonatomic,unsafe_unretained) id<CustomTimePickerDelegate> delegate;
 
 - (id)initWithView:(UIView *)view withDarkTheme:(BOOL)isDarkTheme ;
 

--- a/CustomTimePicker/UI/CustomTimePicker/CustomTimePicker.m
+++ b/CustomTimePicker/UI/CustomTimePicker/CustomTimePicker.m
@@ -24,7 +24,9 @@ alpha:1.0]
 #define kColonHeight 4.0f
 #define kColonOrigin 4.0f
 @interface CustomTimePicker()
+
 -(void)rotateHand:(UIView *)view rotationDegree:(float)degree;
+
 @end
 
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ How To Use
     IBOutlet UIButton *clockButton;
   }
   
-  @property (nonatomic, strong) UIView *clockView;
+  @property (nonatomic, strong) CustomTimePicker *clockView;
   
   -(IBAction)clockButtonPressed:(id)sender;
   

--- a/README.md
+++ b/README.md
@@ -1,25 +1,58 @@
-Android Kitkat like TimePicker for iOS.
+Android Kitkat's TimePicker version for iOS
 
 How To Use
 ---------------
 
-1: Initiate the class
+1. Import CustomTimePicker.h
 
-2: set the delegate.
+2. Set CustomTimePickerDelegate
 
-3: Add to your view.
+3. Implement the Delegate's dismiss method
+
+4. Save/Use the clock's values
 
 
-What it Returns
------------------
+  
+  ClassUsingTimePicker.h
+  ```
+  #import "CustomTimePicker.h"
+  @interface ClassUsingTimePicker.h : UIViewController <CustomTimePickerDelegate> {
+    IBOutlet UIButton *clockButton;
+  }
+  
+  @property (nonatomic, strong) UIView *clockView;
+  
+  -(IBAction)clockButtonPressed:(id)sender;
+  
+  @end
+  ```
+  
+  ClassUsingTimePicker.m
+  ```
+  @implementation ClassUsingTimePicker
+  
+  @synthesize clockView;
+  
+  // Called when clockButton is pressed
+  -(IBAction)clockButtonPressed:(id)sender {
+    clockView = [[CustomTimePicker alloc] initWithView:self.view withDarkTheme:false];
+    clockView.delegate = self;
+    [self.view addSubview:clockView];
+  }
+  
+  // Delegate method called when clockView is dismissed
+  -(void)dismissClockViewWithHours:(NSString *)hours andMinutes:(NSString *)minutes andTimeMode:(NSString *)timeMode {
+    NSLog("%@:%@ %@", hours, minutes, timeMode);
+  }
+  
+  @end
+  ```
+
+What the Delegate returns
+-------------------------
 
 Implementation of delegate will return 3 strings :
 
 1. Hour String.
 2. Minute String.
 3. AM/PM String.
-
-
-Use the output as you like....
-
-

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ How To Use
   
   // Delegate method called when clockView is dismissed
   -(void)dismissClockViewWithHours:(NSString *)hours andMinutes:(NSString *)minutes andTimeMode:(NSString *)timeMode {
-    NSLog("%@:%@ %@", hours, minutes, timeMode);
+    NSLog(@"%@:%@ %@", hours, minutes, timeMode);
   }
   
   @end


### PR DESCRIPTION
CustomTimePicker.h/.m are now fully drag and drop implementation.  iOS 8/Xcode 6 do not use/create .pch files and so UIKit is imported into CustomTimePicker.h directly.
